### PR TITLE
Fix profile modal initialization on login

### DIFF
--- a/srcs/frontend/login/script.js
+++ b/srcs/frontend/login/script.js
@@ -1,6 +1,7 @@
 import { handleRouteChange } from "../router.js";
 import { connectGameServer, disconnectGameServer, } from "../tournament/script.js";
 import { connectChat, disconnectChat } from "../chat/chatWSocket.js";
+import { initNavProfile } from "../chat/app.js";
 let isLogin = true;
 function toggleForm() {
     isLogin = !isLogin;
@@ -64,6 +65,7 @@ async function authenticate() {
                 handleRouteChange();
                 connectGameServer();
                 connectChat();
+                initNavProfile();
             }
             else if (isLogin &&
                 data.message &&
@@ -126,6 +128,7 @@ async function twoFactorAuthenticate() {
             handleRouteChange();
             connectGameServer();
             connectChat();
+            initNavProfile();
         }
         else {
             messageDisplay.textContent = data.error || "Verification failed.";


### PR DESCRIPTION
## Summary
- import `initNavProfile` in login script
- run `initNavProfile()` after a successful login or two‑factor authentication

## Testing
- `node --check srcs/frontend/login/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6867f47b8efc83328ae6d60e0540a24b