### PR TITLE
Fix tournament canvas visuals

### DIFF
--- a/srcs/frontend/game_websocket/pong_websocket.js
+++ b/srcs/frontend/game_websocket/pong_websocket.js
@@ -154,12 +154,17 @@ class Game {
     render() {
         this.ctx.fillStyle = "black";
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.strokeStyle = "#ff2d95";
+        this.ctx.setLineDash([10, 10]);
+        this.ctx.lineWidth = 3;
+        this.ctx.beginPath();
+        this.ctx.moveTo(this.canvas.width / 2, 0);
+        this.ctx.lineTo(this.canvas.width / 2, this.canvas.height);
+        this.ctx.stroke();
+        this.ctx.setLineDash([]);
         this.paddleLeft.draw(this.ctx, this.canvas.height);
         this.paddleRight.draw(this.ctx, this.canvas.height);
         this.ball.draw(this.ctx, this.canvas.height);
-        this.ctx.fillStyle = "white";
-        this.ctx.font = "20px Arial";
-        this.ctx.fillText(`${this.scoreLeft} - ${this.scoreRight}`, this.canvas.width / 2 - 20, 30);
     }
 }
 const canvas = document.getElementById("pongCanvas");

--- a/srcs/frontend/game_websocket/pong_websocket.ts
+++ b/srcs/frontend/game_websocket/pong_websocket.ts
@@ -204,22 +204,25 @@ class Game {
 		});
 	}
 
-	render(): void {
-		this.ctx.fillStyle = "black";
-		this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        render(): void {
+                /* background + centre net */
+                this.ctx.fillStyle = "black";
+                this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
-		this.paddleLeft.draw(this.ctx, this.canvas.height);
-		this.paddleRight.draw(this.ctx, this.canvas.height);
-		this.ball.draw(this.ctx, this.canvas.height);
+                this.ctx.strokeStyle = "#ff2d95";
+                this.ctx.setLineDash([10, 10]);
+                this.ctx.lineWidth = 3;
+                this.ctx.beginPath();
+                this.ctx.moveTo(this.canvas.width / 2, 0);
+                this.ctx.lineTo(this.canvas.width / 2, this.canvas.height);
+                this.ctx.stroke();
+                this.ctx.setLineDash([]);
 
-		this.ctx.fillStyle = "white";
-		this.ctx.font = "20px Arial";
-		this.ctx.fillText(
-			`${this.scoreLeft} - ${this.scoreRight}`,
-			this.canvas.width / 2 - 20,
-			30
-		);
-	}
+                /* objects */
+                this.paddleLeft.draw(this.ctx, this.canvas.height);
+                this.paddleRight.draw(this.ctx, this.canvas.height);
+                this.ball.draw(this.ctx, this.canvas.height);
+        }
 }
 
 const canvas = document.getElementById("pongCanvas") as HTMLCanvasElement;


### PR DESCRIPTION
## Summary
- render the central pink net in tournament games
- stop drawing the score within the tournament canvas

## Testing
- `npx tsc game_websocket/pong_websocket.ts --target ES2022 --lib ES2022,DOM --removeComments --skipLibCheck`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867fcb929e88332acee59450e77eb3d