### PR TITLE
Fix chat socket types

### DIFF
--- a/srcs/frontend/chat/chatWSocket.ts
+++ b/srcs/frontend/chat/chatWSocket.ts
@@ -1,4 +1,4 @@
-import { User, Friend, fetchUserData, addFriend } from "./userdata.js";
+import { type User, type Friend, fetchUserData, addFriend } from "./userdata.js";
 import { openProfile }                     from "../profile.js";
 
 /* ---------- DOM ----------------------------------------------------- */
@@ -33,7 +33,7 @@ let ws: WebSocket | null          = null;
 let currentUserData: User;            // full DB object for me
 let selectedFriend: number = 0;       // 0 = friend-list, -1 = “System”
 let userInfo: UserInfo | null  = null;
-let setIntervalId: NodeJS.Timeout | null = null;
+let setIntervalId: number | null = null;
 
 /* ====================================================================
  *  Connection bootstrap


### PR DESCRIPTION
## Summary
- remove runtime import of `User` and `Friend` by using `import type`
- use browser-safe `number` for `setInterval` id

## Testing
- `npx tsc -p srcs/frontend`

------
https://chatgpt.com/codex/tasks/task_e_686d498d02d08332ae2cb4aefc04d8bf