### PR TITLE
Improve UI layout and chat colors

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -97,8 +97,8 @@
   </div>
 
   <!-- Tournament Page -->
-  <div id="tournamentPage" class="flex gap-6 route-view max-h-[50vh]">
-    <div class="w-1/4 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
+  <div id="tournamentPage" class="route-view flex flex-col md:flex-row gap-6 justify-center items-start max-w-4xl mx-auto">
+    <div class="w-full md:w-1/2 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
       <h2 class="text-xl font-bold mb-4">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
       <form id="createTournamentForm" class="mt-6">
@@ -106,7 +106,7 @@
         <button type="submit" class="w-full bg-blue-900 text-amber-400 font-bold py-2 rounded hover:brightness-90">Create</button>
       </form>
     </div>
-    <div class="flex-1 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
+    <div class="w-full md:w-1/2 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
       <h2 class="text-xl font-bold mb-4" id="selectedTournamentTitle">Select a tournament</h2>
       <p id="statusMessage" class="mb-4 text-sm text-gray-600"></p>
       <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-full flex-1"></ul>
@@ -162,7 +162,7 @@
        class="fixed bottom-4 left-1/2 -translate-x-1/2
               w-11/12 sm:w-3/4 lg:w-2/3
               h-[30vh] max-h-[360px]
-              flex border border-blue-950 bg-amber-50
+              flex border border-blue-950 bg-blue-50
               transition-transform duration-200 transform-gpu
               translate-y-full md:translate-y-0           <!-- closed on mobile -->
               z-40">
@@ -178,7 +178,7 @@
       <h2 class="pb-2 font-bold text-blue-950 border-b border-blue-950">Live Chat</h2>
       <div id="live-chat-content" class="flex-1 flex flex-col-reverse overflow-y-scroll min-h-0 break-all relative"></div>
       <div class="flex flex-row gap-2 p-2 border-t border-blue-950 box-border">
-        <input id="live-message-in" type="text" placeholder="Type a message..." class="flex-1 p-2 border border-blue-950 rounded bg-amber-50 text-blue-950"/>
+        <input id="live-message-in" type="text" placeholder="Type a message..." class="flex-1 p-2 border border-blue-950 rounded bg-blue-50 text-blue-950"/>
         <button id="live-send-button" class="px-4 py-2 bg-blue-900 text-amber-400 font-bold rounded shrink-0 hover:brightness-90">Send</button>
       </div>
     </div>
@@ -188,20 +188,20 @@
         <a id="user-header" class="mx-auto hover:cursor-pointer">Your Username</a>
       </div>
       <div id="friends" class="flex flex-col">
-        <input type="search" id="search-bar" placeholder="Search friends..." class="w-full my-2 p-2 border border-blue-950 rounded bg-amber-50 text-blue-950"/>
+        <input type="search" id="search-bar" placeholder="Search friends..." class="w-full my-2 p-2 border border-blue-950 rounded bg-blue-50 text-blue-950"/>
         <div id="friend-list"></div>
       </div>
       <div id="friend-chat" class="flex flex-col flex-1 overflow-y-auto min-h-0 break-all box-border relative">
         <div id="chat-content" class="flex flex-col flex-1 overflow-y-auto min-h-0 break-all box-border relative"></div>
         <div class="flex flex-row gap-2 p-2 border-t border-blue-950 box-border relative">
-          <input id="message-in" type="text" placeholder="Type a message..." class="flex flex-1 border border-blue-950 rounded bg-amber-50 text-blue-950"/>
+          <input id="message-in" type="text" placeholder="Type a message..." class="flex flex-1 border border-blue-950 rounded bg-blue-50 text-blue-950"/>
           <button id="send-button" class="flex px-4 py-2 bg-blue-900 text-amber-400 font-bold rounded shrink-0 hover:brightness-90">Send</button>
         </div>
       </div>
-      <div id="context-menu" class="absolute text-center bg-amber-50 border border-blue-950 rounded-md hidden">
+      <div id="context-menu" class="absolute text-center bg-blue-50 border border-blue-950 rounded-md hidden">
         <ul class="p-0 m-0 min-w-[150px] list-none">
-          <li id="view-profile" class="py-2 border border-blue-950 rounded-t-md hover:bg-amber-100 hover:text-blue-950">View Profile</li>
-          <li id="invite-user" class="py-2 border border-blue-950 rounded-b-md hover:bg-amber-100 hover:text-blue-950">Invite User</li>
+          <li id="view-profile" class="py-2 border border-blue-950 rounded-t-md hover:bg-blue-100 hover:text-blue-950">View Profile</li>
+          <li id="invite-user" class="py-2 border border-blue-950 rounded-b-md hover:bg-blue-100 hover:text-blue-950">Invite User</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- center the tournament UI with equal width columns
- update chat panel to use light blue colors instead of yellow

## Testing
- `npm run build` (fails to compile TypeScript)
- `npm test` in backend (fails: no test specified)
- `npm run build` in frontend (fails: missing script)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_686d87e4d8588332b362ec2265f72daf