### PR TITLE
Refine tournaments layout

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -97,16 +97,16 @@
   </div>
 
   <!-- Tournament Page -->
-  <div id="tournamentPage" class="route-view flex flex-col md:flex-row gap-6 justify-center items-start max-w-4xl mx-auto">
-    <div class="w-full md:w-1/2 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
+  <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-stretch max-w-4xl mx-auto p-4">
+    <div class="w-full bg-blue-100 border border-blue-950 p-4 rounded-2xl shadow-lg flex flex-col">
       <h2 class="text-xl font-bold mb-4">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
       <form id="createTournamentForm" class="mt-6">
-        <input type="text" id="tournamentName" class="w-full p-2 border border-blue-950 rounded mb-2 bg-amber-50 text-blue-950" placeholder="New Tournament" required/>
+        <input type="text" id="tournamentName" class="w-full p-2 border border-blue-950 rounded mb-2 bg-blue-50 text-blue-950" placeholder="New Tournament" required/>
         <button type="submit" class="w-full bg-blue-900 text-amber-400 font-bold py-2 rounded hover:brightness-90">Create</button>
       </form>
     </div>
-    <div class="w-full md:w-1/2 bg-amber-50 border border-blue-950 p-4 rounded-2xl shadow flex flex-col">
+    <div class="w-full bg-blue-100 border border-blue-950 p-4 rounded-2xl shadow-lg flex flex-col">
       <h2 class="text-xl font-bold mb-4" id="selectedTournamentTitle">Select a tournament</h2>
       <p id="statusMessage" class="mb-4 text-sm text-gray-600"></p>
       <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-full flex-1"></ul>

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -215,7 +215,7 @@ function renderTournamentList(): void {
 		const li = document.createElement("li");
 		li.textContent = t.name;
                 li.className =
-                        "cursor-pointer p-2 rounded border border-blue-950 bg-amber-50 hover:bg-amber-100 text-blue-950";
+                        "cursor-pointer p-2 rounded border border-blue-950 bg-blue-50 hover:bg-blue-100 text-blue-950";
 		li.addEventListener("click", () => selectTournament(t.id));
 		tournamentList.appendChild(li);
 	});
@@ -247,7 +247,7 @@ function selectTournament(id: number): void {
 		const li = document.createElement("li");
 		li.textContent = player.username;
                 li.className =
-                        "border border-blue-950 p-2 rounded bg-amber-50 text-blue-950";
+                        "border border-blue-950 p-2 rounded bg-blue-50 text-blue-950";
 		playerList.appendChild(li);
 	});
 


### PR DESCRIPTION
## Summary
- use blue card styling for tournaments
- stack tournament panels vertically and add page padding
- match list item colors to blue theme

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` in backend (fails: cannot find name 'require')

------
https://chatgpt.com/codex/tasks/task_e_686e3ae85b708332ab9aea7f39903df4