### PR TITLE
Add tournament modal

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -99,15 +99,6 @@
   <!-- Tournament Page -->
   <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center max-w-4xl mx-auto p-4">
     <div class="w-full max-w-md bg-blue-100 p-4 rounded-2xl shadow-lg ring-2 ring-pink-500 filter drop-shadow-[0_0_6px_#ff2d95] flex flex-col">
-      <h2 class="text-xl font-bold mb-4" id="selectedTournamentTitle">Select a tournament</h2>
-      <p id="statusMessage" class="mb-4 text-sm text-gray-600"></p>
-      <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-full flex-1"></ul>
-      <div class="flex gap-4">
-        <button id="subscribeBtn" class="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 hidden">Subscribe</button>
-        <button id="startBtn" class="bg-purple-500 text-white py-2 px-4 rounded hover:bg-purple-600 hidden">Start Tournament</button>
-      </div>
-    </div>
-    <div class="w-full max-w-md bg-blue-100 p-4 rounded-2xl shadow-lg ring-2 ring-pink-500 filter drop-shadow-[0_0_6px_#ff2d95] flex flex-col">
       <h2 class="text-xl font-bold mb-4">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
       <form id="createTournamentForm" class="mt-6">
@@ -244,6 +235,22 @@
     </div>
   </template>
 
+  <!-- Tournament Modal Template -->
+  <template id="tournament-tpl">
+    <div class="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50">
+      <div class="w-full max-w-md bg-blue-100 p-4 rounded-2xl shadow-lg ring-2 ring-pink-500 filter drop-shadow-[0_0_6px_#ff2d95] flex flex-col relative">
+        <button class="close-btn absolute top-2 right-4 bg-none border-none text-2xl leading-none">&times;</button>
+        <h2 class="text-xl font-bold mb-4" id="selectedTournamentTitle">Select a tournament</h2>
+        <p id="statusMessage" class="mb-4 text-sm text-gray-600"></p>
+        <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-60 flex-1"></ul>
+        <div class="flex gap-4">
+          <button id="subscribeBtn" class="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 hidden">Subscribe</button>
+          <button id="startBtn" class="bg-purple-500 text-white py-2 px-4 rounded hover:bg-purple-600 hidden">Start Tournament</button>
+        </div>
+      </div>
+    </div>
+  </template>
+
   <!-- 404 Page -->
   <div id="notFound" class="route-view hidden flex flex-col items-center justify-center h-screen text-center text-red-500">
     <h1 class="text-4xl font-bold mb-2">404</h1>
@@ -265,5 +272,4 @@
 
   <!-- chat show / hide -->
   <script type="module" src="/chat/chatToggle.js"></script>
-
 </body></html>


### PR DESCRIPTION
## Summary
- remove inline player box from tournament page
- add a new modal template for tournament details
- open the modal when a tournament is selected

## Testing
- `npx tsc` (frontend)
- `npm run build` (backend)

------
https://chatgpt.com/codex/tasks/task_e_686e45cd682083328768505f7c59edf8