### PR TITLE
Improve tournament page styling

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -98,12 +98,12 @@
 
   <!-- Tournament Page -->
   <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center max-w-4xl mx-auto p-4">
-    <div class="w-full max-w-md bg-blue-100 p-4 rounded-2xl shadow-lg ring-2 ring-pink-500 filter drop-shadow-[0_0_6px_#ff2d95] flex flex-col">
-      <h2 class="text-xl font-bold mb-4">Tournaments</h2>
+    <div class="w-full max-w-md p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col">
+      <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
       <form id="createTournamentForm" class="mt-6">
-        <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-blue-50 text-blue-950" placeholder="New Tournament" required/>
-        <button type="submit" class="w-full bg-blue-900 text-amber-400 font-bold py-2 rounded hover:brightness-90">Create</button>
+        <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100" placeholder="New Tournament" required/>
+        <button type="submit" class="w-full bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
       </form>
     </div>
   </div>
@@ -238,10 +238,10 @@
   <!-- Tournament Modal Template -->
   <template id="tournament-tpl">
     <div class="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50">
-      <div class="w-full max-w-md bg-blue-100 p-4 rounded-2xl shadow-lg ring-2 ring-pink-500 filter drop-shadow-[0_0_6px_#ff2d95] flex flex-col relative">
+      <div class="w-[460px] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col relative">
         <button class="close-btn absolute top-2 right-4 bg-none border-none text-2xl leading-none">&times;</button>
-        <h2 class="text-xl font-bold mb-4" id="selectedTournamentTitle">Select a tournament</h2>
-        <p id="statusMessage" class="mb-4 text-sm text-gray-600"></p>
+        <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4" id="selectedTournamentTitle">Select a tournament</h2>
+        <p id="statusMessage" class="mb-4 text-sm"></p>
         <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-60 flex-1"></ul>
         <div class="flex gap-4">
           <button id="subscribeBtn" class="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 hidden">Subscribe</button>

--- a/srcs/frontend/tournament/script.js
+++ b/srcs/frontend/tournament/script.js
@@ -119,7 +119,7 @@ function renderTournamentList() {
         const li = document.createElement("li");
         li.textContent = t.name;
         li.className =
-            "cursor-pointer p-2 rounded border border-blue-950 bg-blue-50 hover:bg-blue-100 text-blue-950";
+            "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
         li.addEventListener("click", () => openTournamentModal(t.id));
         tournamentList.appendChild(li);
     });
@@ -178,7 +178,7 @@ function selectTournament(id) {
         const li = document.createElement("li");
         li.textContent = player.username;
         li.className =
-            "border border-blue-950 p-2 rounded bg-blue-50 text-blue-950";
+            "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100";
         playerList.appendChild(li);
     });
     const isCreator = userInfo && userInfo.id === tournament.creator.id;

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -208,7 +208,7 @@ function renderTournamentList(): void {
 		const li = document.createElement("li");
 		li.textContent = t.name;
                 li.className =
-                        "cursor-pointer p-2 rounded border border-blue-950 bg-blue-50 hover:bg-blue-100 text-blue-950";
+                        "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
                 li.addEventListener("click", () => openTournamentModal(t.id));
 		tournamentList.appendChild(li);
 	});
@@ -283,7 +283,7 @@ function selectTournament(id: number): void {
 		const li = document.createElement("li");
 		li.textContent = player.username;
                 li.className =
-                        "border border-blue-950 p-2 rounded bg-blue-50 text-blue-950";
+                        "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100";
 		playerList.appendChild(li);
 	});
 


### PR DESCRIPTION
## Summary
- restyle tournament page container with dark profile modal look
- update tournament modal template to use same colors and fonts
- tweak list item classes and player rows to match new theme

## Testing
- `npx tsc -p srcs/frontend/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686e4a55dd8483328fd3be6bd213f703