### PR TITLE
Adjust tournament UI

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -98,11 +98,11 @@
 
   <!-- Tournament Page -->
   <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center max-w-4xl mx-auto p-4">
-    <div class="w-full max-w-md p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col">
+    <div class="w-full max-w-md sm:max-w-none sm:w-[70%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col mx-auto">
       <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
       <form id="createTournamentForm" class="mt-6">
-        <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100" placeholder="New Tournament" required/>
+        <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
         <button type="submit" class="w-full bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
       </form>
     </div>
@@ -240,7 +240,7 @@
     <div class="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50">
       <div class="w-[460px] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col relative">
         <button class="close-btn absolute top-2 right-4 bg-none border-none text-2xl leading-none">&times;</button>
-        <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4" id="selectedTournamentTitle">Select a tournament</h2>
+        <h2 class="text-pink-400 text-xl font-semibold mb-4 text-center" id="selectedTournamentTitle">Select a tournament</h2>
         <p id="statusMessage" class="mb-4 text-sm"></p>
         <ul id="playerList" class="space-y-2 mb-4 overflow-auto max-h-60 flex-1"></ul>
         <div class="flex gap-4">

--- a/srcs/frontend/tournament/script.js
+++ b/srcs/frontend/tournament/script.js
@@ -119,7 +119,7 @@ function renderTournamentList() {
         const li = document.createElement("li");
         li.textContent = t.name;
         li.className =
-            "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
+            "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100 text-center";
         li.addEventListener("click", () => openTournamentModal(t.id));
         tournamentList.appendChild(li);
     });
@@ -178,7 +178,7 @@ function selectTournament(id) {
         const li = document.createElement("li");
         li.textContent = player.username;
         li.className =
-            "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100";
+            "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100 text-center";
         playerList.appendChild(li);
     });
     const isCreator = userInfo && userInfo.id === tournament.creator.id;

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -208,7 +208,7 @@ function renderTournamentList(): void {
 		const li = document.createElement("li");
 		li.textContent = t.name;
                 li.className =
-                        "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
+                        "cursor-pointer p-2 rounded border border-pink-500 bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100 text-center";
                 li.addEventListener("click", () => openTournamentModal(t.id));
 		tournamentList.appendChild(li);
 	});
@@ -283,7 +283,7 @@ function selectTournament(id: number): void {
 		const li = document.createElement("li");
 		li.textContent = player.username;
                 li.className =
-                        "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100";
+                        "border border-pink-500 p-2 rounded bg-[#1e1e3f] text-pink-100 text-center";
 		playerList.appendChild(li);
 	});
 


### PR DESCRIPTION
## Summary
- enlarge the tournament list box and center input text
- center text for list items
- reduce tournament modal title size

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_686e4d041c2c8332955f4fdc3bb2e8b4