### PR TITLE
Expand tournament page box

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -97,10 +97,10 @@
   </div>
 
   <!-- Tournament Page -->
-  <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center max-w-4xl mx-auto p-4">
-    <div class="w-full max-w-md sm:max-w-none sm:w-[70%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col mx-auto">
+  <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center w-full p-4">
+    <div class="w-full sm:w-[90%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col mx-auto">
       <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center">Tournaments</h2>
-      <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
+      <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1 max-w-md w-full mx-auto"></ul>
       <form id="createTournamentForm" class="mt-6">
         <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
         <button type="submit" class="w-full bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>


### PR DESCRIPTION
## Summary
- enlarge the tournament listing area
- keep tournament list items at a manageable width

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686e4f6229c48332872b881507481477