### PR TITLE
Fix tournament layout widths and height

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -98,12 +98,12 @@
 
   <!-- Tournament Page -->
   <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center w-full p-4">
-    <div class="w-full sm:w-[90%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col mx-auto">
+    <div class="w-full sm:w-[90%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] flex flex-col mx-auto min-h-[80vh]">
       <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center">Tournaments</h2>
       <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1 max-w-md w-full mx-auto"></ul>
-      <form id="createTournamentForm" class="mt-6">
-        <input type="text" id="tournamentName" class="w-full p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
-        <button type="submit" class="w-full bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
+      <form id="createTournamentForm" class="mt-6 max-w-md w-full mx-auto">
+        <input type="text" id="tournamentName" class="w-full max-w-md mx-auto p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
+        <button type="submit" class="w-full max-w-md mx-auto bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- increase height of tournament container so the create form sits lower
- restrict new tournament input and button widths to match the list

## Testing
- `npm test --prefix srcs/backend` *(fails: Error: no test specified)*
- `npx tsc --project srcs/frontend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686e55b0aca8833298f8f1afede8cdf2