### PR TITLE
Fix profile and tournament UI

### DIFF
--- a/srcs/frontend/chat/chatWSocket.js
+++ b/srcs/frontend/chat/chatWSocket.js
@@ -57,7 +57,7 @@ function connectChat() {
             const m = document.createElement("div");
             m.textContent = data.message;
             if (data.sendId) {
-                m.className = "view-profile cursor-pointer";
+                m.className = "view-profile cursor-pointer hover:underline hover:opacity-80";
                 m.dataset.userid = String(data.sendId);
             }
             LChatContent.prepend(m);
@@ -168,7 +168,7 @@ function updateChatHeader(userId = 0) {
     }
     const name = currentUserData.friendlist.find(f => f.id === userId)?.username || "Unknown";
     userHeader.textContent = name;
-    userHeader.classList.add("view-profile");
+    userHeader.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
     userHeader.dataset.userid = String(userId);
     userHeader.onclick = () => openProfile(userId);
 }
@@ -199,7 +199,7 @@ function loadFriendList(list = currentUserData.friendlist) {
         row.className = rowBaseClass(friend.new_message) + " flex items-center gap-2";
         const name = document.createElement("span");
         name.textContent = friend.username;
-        name.className = "view-profile text-blue-950";
+        name.className = "view-profile text-blue-950 cursor-pointer hover:underline hover:opacity-80";
         name.dataset.userid = String(friend.id);
         const dot = document.createElement("span");
         dot.className = friend.online
@@ -311,7 +311,7 @@ function loadSystemChat() {
         const [senderId, msg] = line.split("::");
         const el = document.createElement("div");
         el.textContent = msg;
-        el.className = "view-profile cursor-pointer";
+        el.className = "view-profile cursor-pointer hover:underline hover:opacity-80";
         el.dataset.userid = senderId;
         chatContent.prepend(el);
     });

--- a/srcs/frontend/chat/chatWSocket.ts
+++ b/srcs/frontend/chat/chatWSocket.ts
@@ -75,7 +75,7 @@ function connectChat(): void {
 
       /* make sender’s name clickable if provided */
       if (data.sendId) {
-        m.className = "view-profile cursor-pointer";
+        m.className = "view-profile cursor-pointer hover:underline hover:opacity-80";
         m.dataset.userid = String(data.sendId);
       }
       LChatContent.prepend(m);
@@ -197,7 +197,7 @@ function updateChatHeader(userId: number = 0) {
 
   const name = currentUserData.friendlist.find(f => f.id === userId)?.username || "Unknown";
   userHeader.textContent = name;
-  userHeader.classList.add("view-profile");
+  userHeader.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
   userHeader.dataset.userid = String(userId);
   userHeader.onclick = () => openProfile(userId);
 }
@@ -237,7 +237,7 @@ function loadFriendList(list: Friend[] = currentUserData.friendlist) {
     /* name span → opens profile modal */
     const name = document.createElement("span");
     name.textContent = friend.username;
-    name.className   = "view-profile text-blue-950";
+    name.className   = "view-profile text-blue-950 cursor-pointer hover:underline hover:opacity-80";
     name.dataset.userid = String(friend.id);
 
     /* online status dot */
@@ -373,7 +373,7 @@ function loadSystemChat() {
     const [senderId, msg] = line.split("::");
     const el = document.createElement("div");
     el.textContent = msg;
-    el.className = "view-profile cursor-pointer";
+    el.className = "view-profile cursor-pointer hover:underline hover:opacity-80";
     el.dataset.userid = senderId;
     chatContent.prepend(el);
   });

--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -12,6 +12,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600&display=swap" rel="stylesheet"/>
 
+
+
 </head>
 <body class="bg-blue-100 text-gray-900">
 
@@ -26,7 +28,7 @@
       </div>
       <div class="hidden md:flex items-center space-x-3">
         <span id="navUsername" class="text-sm text-gray-200">John Doe</span>
-        <img id="navAvatar" src="/default-avatar.svg" alt="Avatar" class="w-8 h-8 rounded-full border border-white cursor-pointer view-profile"/>
+        <img id="navAvatar" src="/default-avatar.svg" alt="Avatar" class="w-8 h-8 rounded-full border border-white cursor-pointer view-profile hover:opacity-80"/>
         <button id="logoutBtn" class="text-sm text-red-400 hover:text-red-300 ml-2">Logout</button>
       </div>
       <div class="md:hidden">

--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -33,6 +33,11 @@ export async function openProfile(userId) {
     wireExtraButtons(overlay, data);
     wireFriendBlock(overlay, data);
     if (userId === window.__CURRENT_USER_ID) {
+        const navAvatar = document.getElementById("navAvatar");
+        if (navAvatar)
+            navAvatar.src = data.avatar
+                ? `/uploads/${data.avatar}?_=${Date.now()}`
+                : "/assets/default-avatar.png";
         const tf = wireTwoFactor(overlay, data);
         wireEdit(overlay, data, tf);
     }
@@ -175,7 +180,7 @@ function wireExtraButtons(ov, data) {
         const ul = document.createElement("ul");
         rows.forEach(u => {
             const li = document.createElement("li");
-            li.innerHTML = `<span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline" data-userid="${u.id}">${u.username}</span>`;
+            li.innerHTML = `<span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline hover:opacity-80" data-userid="${u.id}">${u.username}</span>`;
             ul.appendChild(li);
         });
         extraBox.replaceChildren(ul);
@@ -285,7 +290,7 @@ export function initNavProfile() {
     const avatarEl = document.getElementById("navAvatar");
     if (avatarEl) {
         avatarEl.dataset.userid = String(userInfoGlobal.id);
-        avatarEl.classList.add("view-profile", "cursor-pointer");
+        avatarEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
     }
     (async () => {
         const userInfo = userInfoGlobal;
@@ -299,12 +304,16 @@ export function initNavProfile() {
         }
         __CURRENT_USER_ID = window.__CURRENT_USER_ID = me.id;
         const avatar = document.getElementById("navAvatar");
-        if (avatar)
+        if (avatar) {
             avatar.dataset.userid = String(me.id);
+            avatar.src = me.avatar ? `/uploads/${me.avatar}?_=${Date.now()}` : "/assets/default-avatar.png";
+        }
         const nameEl = document.getElementById("navUsername");
         if (nameEl) {
+            const aliasVal = (me.alias ?? "").trim() || me.username;
+            nameEl.textContent = aliasVal;
             nameEl.dataset.userid = String(me.id);
-            nameEl.classList.add("view-profile", "cursor-pointer");
+            nameEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
         }
     })();
     if (!_navProfileInitDone) {
@@ -328,8 +337,10 @@ export function initNavProfile() {
     }
     const nameEl = document.getElementById("navUsername");
     if (nameEl) {
+        const aliasVal = (userInfoGlobal.alias ?? "").trim() || userInfoGlobal.username;
+        nameEl.textContent = aliasVal;
         nameEl.dataset.userid = String(userInfoGlobal.id);
-        nameEl.classList.add("view-profile", "cursor-pointer");
+        nameEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
     }
 }
 initNavProfile();

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -78,8 +78,14 @@ let _navProfileInitDone = false;
     wireExtraButtons(overlay, data);
     wireFriendBlock(overlay, data);
 
-    // Editing / 2FA only for own profile
+    // If viewing own profile, also refresh the navbar avatar
     if (userId === window.__CURRENT_USER_ID) {
+      const navAvatar = document.getElementById("navAvatar") as HTMLImageElement | null;
+      if (navAvatar)
+        navAvatar.src = data.avatar
+          ? `/uploads/${data.avatar}?_=${Date.now()}`
+          : "/assets/default-avatar.png";
+
       const tf = wireTwoFactor(overlay, data);
       wireEdit(overlay, data, tf);
     }
@@ -275,7 +281,7 @@ let _navProfileInitDone = false;
       const ul = document.createElement("ul");
       rows.forEach(u => {
         const li = document.createElement("li");
-        li.innerHTML = `<span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline" data-userid="${u.id}">${u.username}</span>`;
+        li.innerHTML = `<span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline hover:opacity-80" data-userid="${u.id}">${u.username}</span>`;
         ul.appendChild(li);
       });
       extraBox.replaceChildren(ul);
@@ -410,7 +416,7 @@ export function initNavProfile(): void {
   const avatarEl = document.getElementById("navAvatar");
   if (avatarEl) {
     avatarEl.dataset.userid = String(userInfoGlobal.id);
-    avatarEl.classList.add("view-profile", "cursor-pointer");
+    avatarEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
   }
 
   (async () => {
@@ -422,12 +428,17 @@ export function initNavProfile(): void {
     }).then(r => r.json()).catch(() => null);
     if (!me) { window.location.href = "/login"; return; }
     __CURRENT_USER_ID = window.__CURRENT_USER_ID = me.id;
-    const avatar = document.getElementById("navAvatar");
-    if (avatar) avatar.dataset.userid = String(me.id);
+    const avatar = document.getElementById("navAvatar") as HTMLImageElement | null;
+    if (avatar) {
+      avatar.dataset.userid = String(me.id);
+      avatar.src = me.avatar ? `/uploads/${me.avatar}?_=${Date.now()}` : "/assets/default-avatar.png";
+    }
     const nameEl = document.getElementById("navUsername");
     if (nameEl) {
+      const aliasVal = (me.alias ?? "").trim() || me.username;
+      nameEl.textContent = aliasVal;
       nameEl.dataset.userid = String(me.id);
-      nameEl.classList.add("view-profile", "cursor-pointer");
+      nameEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
     }
   })();
 
@@ -456,10 +467,11 @@ export function initNavProfile(): void {
 
   const nameEl = document.getElementById("navUsername");
   if (nameEl) {
+    const aliasVal = (userInfoGlobal.alias ?? "").trim() || userInfoGlobal.username;
+    nameEl.textContent = aliasVal;
     nameEl.dataset.userid = String(userInfoGlobal.id);
-    nameEl.classList.add("view-profile", "cursor-pointer");
+    nameEl.classList.add("view-profile", "cursor-pointer", "hover:underline", "hover:opacity-80");
   }
 }
 
-initNavProfile();
- 
+initNavProfile(); 

--- a/srcs/frontend/router.js
+++ b/srcs/frontend/router.js
@@ -64,11 +64,11 @@ function handleRouteChange() {
     }
     else {
         navBar?.classList.remove("hidden");
-        document.getElementById("navUsername").textContent =
-            user.username || "Guest";
-        document
-            .getElementById("navAvatar")
-            .setAttribute("src", user.avatar || "default-avatar.svg");
+        const aliasVal = (user.alias ?? "").trim() || user.username || "Guest";
+        document.getElementById("navUsername").textContent = aliasVal;
+        const navAv = document.getElementById("navAvatar");
+        if (navAv)
+            navAv.setAttribute("src", user.avatar ? `/uploads/${user.avatar}?_=${Date.now()}` : "/assets/default-avatar.png");
         if (path === "/login") {
             history.replaceState({}, "", "/tournament");
             path = "/tournament";

--- a/srcs/frontend/router.ts
+++ b/srcs/frontend/router.ts
@@ -1,10 +1,11 @@
 type Routes = Record<string, string>;
 
 interface userInfo {
-	id: number;
-	token: string;
-	username: string;
-	avatar: string | null;
+        id: number;
+        token: string;
+        username: string;
+        avatar: string | null;
+        alias?: string | null;
 }
 
 const routes: Routes = {
@@ -79,11 +80,11 @@ function handleRouteChange(): void {
                 path = "/login";
         } else {
                 navBar?.classList.remove("hidden");
-                document.getElementById("navUsername").textContent =
-                        user.username || "Guest";
-                document
-                        .getElementById("navAvatar")
-                        .setAttribute("src", user.avatar || "default-avatar.svg");
+                const aliasVal = (user.alias ?? "").trim() || user.username || "Guest";
+                document.getElementById("navUsername").textContent = aliasVal;
+                const navAv = document.getElementById("navAvatar");
+                if (navAv)
+                        navAv.setAttribute("src", user.avatar ? `/uploads/${user.avatar}?_=${Date.now()}` : "/assets/default-avatar.png");
                 if (path === "/login") {
                         history.replaceState({}, "", "/tournament");
                         path = "/tournament";

--- a/srcs/frontend/tournament/script.js
+++ b/srcs/frontend/tournament/script.js
@@ -259,8 +259,11 @@ async function updateGameHeader(tournamentUpdateMessage) {
     });
     const player1Data = await response.json();
     if (response.ok && player1Data) {
-        player1Name.textContent = player1Data.username;
-        player1Avatar.src = player1Data.avatar || "default-avatar.svg";
+        const alias1 = (player1Data.alias ?? "").trim() || player1Data.username;
+        player1Name.textContent = alias1;
+        player1Avatar.src = player1Data.avatar
+            ? `/uploads/${player1Data.avatar}?_=${Date.now()}`
+            : "/assets/default-avatar.png";
     }
     response = await fetch("/user/" + player2.id, {
         method: "GET",
@@ -270,8 +273,11 @@ async function updateGameHeader(tournamentUpdateMessage) {
     });
     const player2Data = await response.json();
     if (response.ok && player2Data) {
-        player2Name.textContent = player2Data.username;
-        player2Avatar.src = player2Data.avatar || "default-avatar.svg";
+        const alias2 = (player2Data.alias ?? "").trim() || player2Data.username;
+        player2Name.textContent = alias2;
+        player2Avatar.src = player2Data.avatar
+            ? `/uploads/${player2Data.avatar}?_=${Date.now()}`
+            : "/assets/default-avatar.png";
     }
     const player1Score = player1.score || 0;
     const player2Score = player2.score || 0;

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -384,22 +384,28 @@ async function updateGameHeader(
 			Authorization: `Bearer ${localStorage.getItem("token")}`,
 		},
 	});
-	const player1Data = await response.json();
-	if (response.ok && player1Data) {
-		player1Name.textContent = player1Data.username;
-		player1Avatar.src = player1Data.avatar || "default-avatar.svg"; // Fallback avatar
-	}
+        const player1Data = await response.json();
+        if (response.ok && player1Data) {
+                const alias1 = (player1Data.alias ?? "").trim() || player1Data.username;
+                player1Name.textContent = alias1;
+                player1Avatar.src = player1Data.avatar
+                        ? `/uploads/${player1Data.avatar}?_=${Date.now()}`
+                        : "/assets/default-avatar.png";
+        }
 	response = await fetch("/user/" + player2.id, {
 		method: "GET",
 		headers: {
 			Authorization: `Bearer ${localStorage.getItem("token")}`,
 		},
 	});
-	const player2Data = await response.json();
-	if (response.ok && player2Data) {
-		player2Name.textContent = player2Data.username;
-		player2Avatar.src = player2Data.avatar || "default-avatar.svg"; // Fallback avatar
-	}
+        const player2Data = await response.json();
+        if (response.ok && player2Data) {
+                const alias2 = (player2Data.alias ?? "").trim() || player2Data.username;
+                player2Name.textContent = alias2;
+                player2Avatar.src = player2Data.avatar
+                        ? `/uploads/${player2Data.avatar}?_=${Date.now()}`
+                        : "/assets/default-avatar.png";
+        }
 	const player1Score = player1.score || 0;
 	const player2Score = player2.score || 0;
 	scoreDisplay.textContent = `${player1Score} - ${player2Score}`;


### PR DESCRIPTION
## Summary
- style `.view-profile` with hover effect
- keep navbar avatar in sync with user profile
- display user alias across the app
- ensure tournament header shows correct avatars
- use Tailwind classes for all profile hover styles

## Testing
- `npx tsc -p srcs/frontend/tsconfig.json`
- `node -c srcs/frontend/profile.js`
- `node -c srcs/frontend/tournament/script.js`


------
https://chatgpt.com/codex/tasks/task_e_686e6e31026c833285c2fa373c2553f6