### PR TITLE
Add avatar URL helper

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -1,6 +1,11 @@
 let __CURRENT_USER_ID = null;
 window.__CURRENT_USER_ID = null;
 let _navProfileInitDone = false;
+export function getAvatarUrl(avatar) {
+    if (!avatar)
+        return null;
+    return avatar.startsWith("http") ? avatar : `/uploads/${avatar}`;
+}
 export async function openProfile(userId) {
     const tpl = document.getElementById("profile-tpl");
     if (!tpl)
@@ -36,7 +41,7 @@ export async function openProfile(userId) {
         const navAvatar = document.getElementById("navAvatar");
         if (navAvatar)
             navAvatar.src = data.avatar
-                ? `/uploads/${data.avatar}?_=${Date.now()}`
+                ? `${getAvatarUrl(data.avatar)}?_=${Date.now()}`
                 : "/assets/default-avatar.png";
         const tf = wireTwoFactor(overlay, data);
         wireEdit(overlay, data, tf);
@@ -306,7 +311,7 @@ export function initNavProfile() {
         const avatar = document.getElementById("navAvatar");
         if (avatar) {
             avatar.dataset.userid = String(me.id);
-            avatar.src = me.avatar ? `/uploads/${me.avatar}?_=${Date.now()}` : "/assets/default-avatar.png";
+            avatar.src = me.avatar ? `${getAvatarUrl(me.avatar)}?_=${Date.now()}` : "/assets/default-avatar.png";
         }
         const nameEl = document.getElementById("navUsername");
         if (nameEl) {

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -12,6 +12,16 @@ declare global {
 let __CURRENT_USER_ID: number | null = null;
 window.__CURRENT_USER_ID = null;
 let _navProfileInitDone = false;
+
+/**
+ * Return an absolute avatar URL for the given value. If the avatar already
+ * contains an "http" prefix it is assumed to be a complete URL. Otherwise the
+ * avatar is served from our uploads folder.
+ */
+export function getAvatarUrl(avatar: string | null): string | null {
+  if (!avatar) return null;
+  return avatar.startsWith("http") ? avatar : `/uploads/${avatar}`;
+}
   
   export interface UserProfileData {
     id: number;
@@ -83,7 +93,7 @@ let _navProfileInitDone = false;
       const navAvatar = document.getElementById("navAvatar") as HTMLImageElement | null;
       if (navAvatar)
         navAvatar.src = data.avatar
-          ? `/uploads/${data.avatar}?_=${Date.now()}`
+          ? `${getAvatarUrl(data.avatar)}?_=${Date.now()}`
           : "/assets/default-avatar.png";
 
       const tf = wireTwoFactor(overlay, data);
@@ -431,7 +441,7 @@ export function initNavProfile(): void {
     const avatar = document.getElementById("navAvatar") as HTMLImageElement | null;
     if (avatar) {
       avatar.dataset.userid = String(me.id);
-      avatar.src = me.avatar ? `/uploads/${me.avatar}?_=${Date.now()}` : "/assets/default-avatar.png";
+      avatar.src = me.avatar ? `${getAvatarUrl(me.avatar)}?_=${Date.now()}` : "/assets/default-avatar.png";
     }
     const nameEl = document.getElementById("navUsername");
     if (nameEl) {

--- a/srcs/frontend/router.js
+++ b/srcs/frontend/router.js
@@ -1,3 +1,4 @@
+import { getAvatarUrl } from "./profile.js";
 const routes = {
     "/home": "home",
     "/login": "loginPage",
@@ -68,7 +69,7 @@ function handleRouteChange() {
         document.getElementById("navUsername").textContent = aliasVal;
         const navAv = document.getElementById("navAvatar");
         if (navAv)
-            navAv.setAttribute("src", user.avatar ? `/uploads/${user.avatar}?_=${Date.now()}` : "/assets/default-avatar.png");
+            navAv.setAttribute("src", user.avatar ? `${getAvatarUrl(user.avatar)}?_=${Date.now()}` : "/assets/default-avatar.png");
         if (path === "/login") {
             history.replaceState({}, "", "/tournament");
             path = "/tournament";

--- a/srcs/frontend/router.ts
+++ b/srcs/frontend/router.ts
@@ -1,3 +1,5 @@
+import { getAvatarUrl } from "./profile.js";
+
 type Routes = Record<string, string>;
 
 interface userInfo {
@@ -84,7 +86,7 @@ function handleRouteChange(): void {
                 document.getElementById("navUsername").textContent = aliasVal;
                 const navAv = document.getElementById("navAvatar");
                 if (navAv)
-                        navAv.setAttribute("src", user.avatar ? `/uploads/${user.avatar}?_=${Date.now()}` : "/assets/default-avatar.png");
+                        navAv.setAttribute("src", user.avatar ? `${getAvatarUrl(user.avatar)}?_=${Date.now()}` : "/assets/default-avatar.png");
                 if (path === "/login") {
                         history.replaceState({}, "", "/tournament");
                         path = "/tournament";


### PR DESCRIPTION
## Summary
- add `getAvatarUrl` to normalize avatar URLs
- use helper when updating navbar avatar in profile views
- update router to use helper for avatar
- compile TypeScript

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688b8c303cb88332923e0752a27dc0a8