### PR TITLE
Add clickable profiles in tournament header

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -118,12 +118,12 @@
     <div id="pongHeader" class="flex items-center justify-between px-6 py-4 w-full">
       <div class="flex items-center gap-3">
         <img id="player1Avatar" src="/default-avatar.svg" alt="Player 1 Avatar" class="w-10 h-10 rounded-full object-cover"/>
-        <span id="player1Name" class="text-lg font-medium">Player1</span>
+        <span id="player1Name" class="view-profile cursor-pointer hover:underline hover:opacity-80 text-lg font-medium">Player1</span>
       </div>
       <div id="scoreDisplay" class="text-3xl text-[#00bfff] drop-shadow-[0_0_6px_#00bfff] font-['Press_Start_2P',sans-serif]">0 - 0</div>
       <div id="countDownDisplay" class="hidden text-3xl text-[#00bfff] drop-shadow-[0_0_6px_#00bfff] font-['Press_Start_2P',sans-serif]">5</div>
       <div class="flex items-center gap-3">
-        <span id="player2Name" class="text-lg font-medium">Player2</span>
+        <span id="player2Name" class="view-profile cursor-pointer hover:underline hover:opacity-80 text-lg font-medium">Player2</span>
         <img id="player2Avatar" src="/default-avatar.svg" alt="Player 2 Avatar" class="w-10 h-10 rounded-full object-cover"/>
       </div>
     </div>

--- a/srcs/frontend/tournament/script.js
+++ b/srcs/frontend/tournament/script.js
@@ -189,6 +189,7 @@ function closeTournamentModal() {
     selectedTournament = null;
 }
 function selectTournament(id) {
+    console.log("Selected tournament:", id);
     selectedTournament = id;
     if (!selectedTitle || !statusMessage || !playerList || !subscribeBtn || !startBtn) {
         return;
@@ -250,6 +251,8 @@ const scoreDisplay = document.getElementById("scoreDisplay");
 const countDownDisplay = document.getElementById("countDownDisplay");
 async function updateGameHeader(tournamentUpdateMessage) {
     const { player1, player2 } = tournamentUpdateMessage.data;
+    player1Name.dataset.userid = String(player1.id);
+    player2Name.dataset.userid = String(player2.id);
     let response = await fetch("/user/" + player1.id, {
         method: "GET",
         headers: {

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -371,9 +371,12 @@ const countDownDisplay = document.getElementById(
 
 // Update game header with player info
 async function updateGameHeader(
-	tournamentUpdateMessage: tournamentUpdateMessage
+        tournamentUpdateMessage: tournamentUpdateMessage
 ): Promise<void> {
-	const { player1, player2 } = tournamentUpdateMessage.data;
+        const { player1, player2 } = tournamentUpdateMessage.data;
+
+        player1Name.dataset.userid = String(player1.id);
+        player2Name.dataset.userid = String(player2.id);
 
 	//player1Name.textContent = player1.username;
 	//player2Name.textContent = player2.username;


### PR DESCRIPTION
## Summary
- make player names clickable in tournament header
- expose player IDs in tournament UI for profile viewer
- rebuild frontend JS

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688b8e6dd2b8833286d31646fa7b3714