### PR TITLE
Swap tournament form order

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -102,11 +102,11 @@
   <div id="tournamentPage" class="route-view flex flex-col gap-6 justify-center items-center w-full p-4">
     <div class="w-full sm:w-[90%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] grid sm:grid-cols-2 gap-6 mx-auto min-h-[60vh]">
       <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center sm:col-span-2">Tournaments</h2>
-      <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1 max-w-md w-full mx-auto sm:mr-6 sm:pr-6 sm:border-r sm:border-pink-500"></ul>
-      <form id="createTournamentForm" class="mt-6 sm:mt-0 self-start max-w-md w-full mx-auto sm:pl-6">
+      <form id="createTournamentForm" class="mt-6 sm:mt-0 self-start max-w-md w-full mx-auto sm:mr-6 sm:pr-6 sm:border-r sm:border-pink-500">
         <input type="text" id="tournamentName" class="w-full max-w-md mx-auto p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
         <button type="submit" class="w-full max-w-md mx-auto bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
       </form>
+      <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1 max-w-md w-full mx-auto sm:pl-6"></ul>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- move Tournament creation form before list
- adjust spacing classes so layout stays aligned

## Testing
- `npm test --prefix srcs/backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bcc56e2408332823a68149aaf33c4