### PR TITLE
Improve tournament list view

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -103,10 +103,14 @@
     <div class="w-full sm:w-[90%] p-6 rounded-lg bg-[#131325] ring-2 ring-pink-500 shadow-xl text-pink-100 font-['Rubik',sans-serif] grid sm:grid-cols-2 gap-6 mx-auto min-h-[60vh]">
       <h2 class="text-pink-400 text-2xl font-['Press_Start_2P',sans-serif] mb-4 text-center sm:col-span-2">Tournaments</h2>
       <form id="createTournamentForm" class="mt-6 sm:mt-0 self-start max-w-md w-full mx-auto sm:mr-6 sm:pr-6 sm:border-r sm:border-pink-500">
+        <h3 class="text-lg font-semibold mb-2 text-center sm:text-left">Create a New Tournament</h3>
         <input type="text" id="tournamentName" class="w-full max-w-md mx-auto p-2 border border-pink-500 rounded mb-2 bg-[#1e1e3f] text-pink-100 text-center" placeholder="New Tournament" required/>
         <button type="submit" class="w-full max-w-md mx-auto bg-emerald-500 text-white font-semibold py-2 rounded hover:bg-emerald-600">Create</button>
       </form>
-      <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1 max-w-md w-full mx-auto sm:pl-6"></ul>
+      <div class="max-w-md w-full mx-auto sm:pl-6">
+        <h3 class="text-lg font-semibold mb-2 text-center sm:text-left">Available Tournaments</h3>
+        <ul id="tournamentList" class="space-y-2 overflow-auto max-h-full flex-1"></ul>
+      </div>
     </div>
   </div>
 

--- a/srcs/frontend/tournament/script.js
+++ b/srcs/frontend/tournament/script.js
@@ -138,14 +138,15 @@ function renderTournamentList() {
     tournaments.forEach((t) => {
         const li = document.createElement("li");
         const subscribed = userInfo && t.players.some((p) => p.id === userInfo.id);
-        li.innerHTML = subscribed
-            ? `${t.name} <span class="ml-1 text-green-400">✓</span>`
-            : t.name;
         li.className =
-            "cursor-pointer p-2 rounded border border-pink-500 text-center ";
+            "cursor-pointer p-4 rounded border border-pink-500 text-center shadow hover:shadow-lg transition-shadow ";
         li.className += subscribed
             ? "bg-green-800 text-white"
             : "bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
+        li.innerHTML = `
+                        <div class="font-semibold">${t.name}${subscribed ? ' <span class="ml-1 text-green-400">✓</span>' : ''}</div>
+                        <div class="text-sm text-pink-300">Creator: ${t.creator.username}</div>
+                        <div class="text-sm text-pink-300">${t.players.length} player${t.players.length !== 1 ? 's' : ''}</div>`;
         li.addEventListener("click", () => openTournamentModal(t.id));
         tournamentList.appendChild(li);
     });

--- a/srcs/frontend/tournament/script.ts
+++ b/srcs/frontend/tournament/script.ts
@@ -230,14 +230,15 @@ function renderTournamentList(): void {
                 const li = document.createElement("li");
                 const subscribed =
                         userInfo && t.players.some((p) => p.id === userInfo!.id);
-                li.innerHTML = subscribed
-                        ? `${t.name} <span class="ml-1 text-green-400">✓</span>`
-                        : t.name;
                 li.className =
-                        "cursor-pointer p-2 rounded border border-pink-500 text-center ";
+                        "cursor-pointer p-4 rounded border border-pink-500 text-center shadow hover:shadow-lg transition-shadow ";
                 li.className += subscribed
                         ? "bg-green-800 text-white"
                         : "bg-[#1e1e3f] hover:bg-[#2a2a55] text-pink-100";
+                li.innerHTML = `
+                        <div class="font-semibold">${t.name}${subscribed ? ' <span class="ml-1 text-green-400">✓</span>' : ''}</div>
+                        <div class="text-sm text-pink-300">Creator: ${t.creator.username}</div>
+                        <div class="text-sm text-pink-300">${t.players.length} player${t.players.length !== 1 ? 's' : ''}</div>`;
                 li.addEventListener("click", () => openTournamentModal(t.id));
                 tournamentList.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- add headings to tournament sections
- render tournament cards with name, creator and player count
- apply shadow + hover effects for tournament cards

## Testing
- `npx tsc -p srcs/frontend/tsconfig.json`
- `node test/db_query.js` *(fails: SQLITE_ERROR no such table)*
- `node test/email.js` *(fails: ESOCKET connect 209.85.145.108:465)*
- `node test/update_db.js` *(fails: SQLITE_ERROR no such table)*

------
https://chatgpt.com/codex/tasks/task_e_688bcd51e7f883329ef1cf0956c6011e