### PR TITLE
Fix chat overlay default

### DIFF
--- a/srcs/frontend/chat/chatToggle.js
+++ b/srcs/frontend/chat/chatToggle.js
@@ -25,12 +25,7 @@ function toggleChat() {
         hideChat();
     }
 }
-if (window.innerWidth < 768) {
-    hideChat();
-}
-else {
-    showChat();
-}
+hideChat();
 hideBtn?.addEventListener('click', toggleChat);
 toggleBtn?.addEventListener('click', showChat);
 window.addEventListener('resize', () => {

--- a/srcs/frontend/chat/chatToggle.ts
+++ b/srcs/frontend/chat/chatToggle.ts
@@ -25,11 +25,7 @@ function toggleChat(): void {
   }
 }
 
-if (window.innerWidth < 768) {
-  hideChat();
-} else {
-  showChat();
-}
+hideChat();
 
 hideBtn?.addEventListener('click', toggleChat);
 toggleBtn?.addEventListener('click', showChat);

--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -162,7 +162,7 @@
               flex border border-blue-950 bg-blue-50
              rounded-lg shadow-lg overflow-visible
               transition-transform duration-200 transform-gpu
-              translate-y-full md:translate-y-0           <!-- closed on mobile -->
+              translate-y-full           <!-- closed by default -->
               z-40">
 
     <!-- “–” HIDE BUTTON (always visible while panel is shown) -->


### PR DESCRIPTION
## Summary
- hide chat panel by default on all screens
- keep toggle script consistent with new behaviour

## Testing
- `npx tsc chat/chatToggle.ts`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_688bddc99864833283afe2f13c7cefba