### PR TITLE
Fix profile modal button spacing

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -228,7 +228,7 @@
         <p class="private hidden" id="pr-2fa-row">
           <label><input type="checkbox" id="pr-2fa"> Two Factor Authentication</label>
         </p>
-        <footer>
+        <footer class="flex flex-wrap gap-2">
           <button id="pr-edit" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Edit</button>
           <button id="pr-save" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Save</button>
           <button id="pr-cancel" class="inline-block px-3 py-1 rounded-md bg-emerald-500 text-white font-semibold hover:bg-emerald-600 hidden">Cancel</button>


### PR DESCRIPTION
## Summary
- add flex layout and gaps around profile buttons to prevent overlap

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688cb85548288332bd1d63f2e44a867e