### PR TITLE
Enable viewing opponent profile from match history

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -245,12 +245,13 @@ function wireExtraButtons(ov, data) {
             const row = document.createElement("tr");
             const youWon = g.winnerId === data.id;
             const opponentName = youWon ? g.loser_username : g.winner_username;
+            const opponentId = youWon ? g.loserId : g.winnerId;
             let tournament = "";
             if (includeTournament)
                 tournament = g.tournament_name ?? String(g.tournamentId ?? "");
             row.innerHTML =
                 `<td class="px-2">${g.timestamp.slice(0, 10)}</td>` +
-                    `<td class="px-2">${opponentName ?? ""}</td>` +
+                    `<td class="px-2"><span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline hover:opacity-80" data-userid="${opponentId}">${opponentName ?? ""}</span></td>` +
                     `<td class="px-2">${youWon ? "Win" : "Loss"}</td>` +
                     `<td class="px-2">${g.scoreWinner} – ${g.scoreLoser}</td>` +
                     (includeTournament ? `<td class="px-2">${tournament}</td>` : "");

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -367,13 +367,14 @@ export interface GameHistoryRow {
         const row = document.createElement("tr");
         const youWon = g.winnerId === data.id;
         const opponentName = youWon ? g.loser_username : g.winner_username;
+        const opponentId = youWon ? g.loserId : g.winnerId;
         let tournament = "";
         if (includeTournament)
           tournament = g.tournament_name ?? String(g.tournamentId ?? "");
 
         row.innerHTML =
           `<td class="px-2">${g.timestamp.slice(0, 10)}</td>` +
-          `<td class="px-2">${opponentName ?? ""}</td>` +
+          `<td class="px-2"><span class="view-profile cursor-pointer text-[color:var(--link,#06c)] hover:underline hover:opacity-80" data-userid="${opponentId}">${opponentName ?? ""}</span></td>` +
           `<td class="px-2">${youWon ? "Win" : "Loss"}</td>` +
           `<td class="px-2">${g.scoreWinner} – ${g.scoreLoser}</td>` +
           (includeTournament ? `<td class="px-2">${tournament}</td>` : "");


### PR DESCRIPTION
## Summary
- allow direct profile access from match history by adding `view-profile` spans around opponent names in `profile.ts` and compiled JS

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_688cd07d3c2083329f6a69c5235be104