### PR TITLE
Fix profile history toggle

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -191,7 +191,14 @@ function wireExtraButtons(ov, data) {
     const histBtn = ov.querySelector("#pr-history");
     const extraBox = ov.querySelector("#pr-extra");
     const token = localStorage.getItem("token");
+    let currentView = null;
     friendsBtn.onclick = async () => {
+        if (currentView === "friends") {
+            extraBox.replaceChildren();
+            currentView = null;
+            return;
+        }
+        currentView = "friends";
         extraBox.innerHTML = "<p>Loading…</p>";
         let rows = [];
         try {
@@ -215,6 +222,12 @@ function wireExtraButtons(ov, data) {
         extraBox.replaceChildren(ul);
     };
     histBtn.onclick = async () => {
+        if (currentView === "history") {
+            extraBox.replaceChildren();
+            currentView = null;
+            return;
+        }
+        currentView = "history";
         extraBox.innerHTML = "<p>Loading…</p>";
         let games = [];
         try {

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -303,8 +303,17 @@ export interface GameHistoryRow {
     const histBtn    = ov.querySelector<HTMLButtonElement>("#pr-history")!;
     const extraBox   = ov.querySelector<HTMLElement>("#pr-extra")!;
     const token      = localStorage.getItem("token");
+
+    let currentView: "friends" | "history" | null = null;
   
     friendsBtn.onclick = async () => {
+      if (currentView === "friends") {
+        extraBox.replaceChildren();
+        currentView = null;
+        return;
+      }
+
+      currentView = "friends";
       extraBox.innerHTML = "<p>Loading…</p>";
       let rows: FriendRow[] = [];
       try {
@@ -315,12 +324,12 @@ export interface GameHistoryRow {
       } catch {
         /* ignore */
       }
-  
+
       if (!Array.isArray(rows) || !rows.length) {
         extraBox.textContent = "No friends to show.";
         return;
       }
-  
+
       const ul = document.createElement("ul");
       rows.forEach(u => {
         const li = document.createElement("li");
@@ -331,6 +340,13 @@ export interface GameHistoryRow {
     };
   
     histBtn.onclick = async () => {
+      if (currentView === "history") {
+        extraBox.replaceChildren();
+        currentView = null;
+        return;
+      }
+
+      currentView = "history";
       extraBox.innerHTML = "<p>Loading…</p>";
       let games: GameHistoryRow[] = [];
       try {


### PR DESCRIPTION
## Summary
- add toggle behaviour to match history list

## Testing
- `npx tsc` in `srcs/backend`
- `npx tsc` in `srcs/frontend`


------
https://chatgpt.com/codex/tasks/task_e_688cd430dd8c83328f173d487c0ae4bb