### PR TITLE
Add countdown sound effect

### DIFF
--- a/srcs/frontend/index.html
+++ b/srcs/frontend/index.html
@@ -151,6 +151,7 @@
       <audio id="sndWall" src="assets/wall.wav" preload="auto"></audio>
       <audio id="sndPaddle" src="assets/paddle.wav" preload="auto"></audio>
       <audio id="sndScore" src="assets/score.wav" preload="auto"></audio>
+      <audio id="sndCountdown" src="assets/countdown.wav" preload="auto"></audio>
     </div>
   </div>
 

--- a/srcs/frontend/pong.js
+++ b/srcs/frontend/pong.js
@@ -14,6 +14,7 @@ const SFX = {
     wall: document.getElementById('sndWall'),
     paddle: document.getElementById('sndPaddle'),
     score: document.getElementById('sndScore'),
+    countdown: document.getElementById('sndCountdown'),
 };
 class Paddle {
     x;
@@ -214,6 +215,8 @@ class Game {
         countdownEl.classList.remove('hidden');
         let n = 3;
         countdownEl.textContent = n.toString();
+        SFX.countdown.currentTime = 0;
+        SFX.countdown.play();
         const iv = setInterval(() => {
             n--;
             if (n === 0) {
@@ -223,6 +226,8 @@ class Game {
             }
             else {
                 countdownEl.textContent = n.toString();
+                SFX.countdown.currentTime = 0;
+                SFX.countdown.play();
             }
         }, 800);
     }

--- a/srcs/frontend/pong.ts
+++ b/srcs/frontend/pong.ts
@@ -37,6 +37,7 @@ const SFX = {
   wall   : document.getElementById('sndWall')   as HTMLAudioElement,
   paddle : document.getElementById('sndPaddle') as HTMLAudioElement,
   score  : document.getElementById('sndScore')  as HTMLAudioElement,
+  countdown : document.getElementById('sndCountdown') as HTMLAudioElement,
 };
 
 /* ------------------------------------------------------------------------
@@ -266,6 +267,8 @@ class Game {
     countdownEl.classList.remove('hidden');
     let n = 3;
     countdownEl.textContent = n.toString();
+    SFX.countdown.currentTime = 0;
+    SFX.countdown.play();
     const iv = setInterval(() => {
       n--;
       if (n === 0) {
@@ -274,6 +277,8 @@ class Game {
         callback();
       } else {
         countdownEl.textContent = n.toString();
+        SFX.countdown.currentTime = 0;
+        SFX.countdown.play();
       }
     }, 800);
   }


### PR DESCRIPTION
## Summary
- add countdown audio element in `index.html`
- play countdown sound during local game countdown

## Testing
- `npm test` in `srcs/backend` *(fails: Error: no test specified)*
- `npm test` in `srcs/frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688cd9c2e6ac8332bc17429db38ea1c3