### PR TITLE
Fix countdown SFX replay

### DIFF
--- a/srcs/frontend/pong.js
+++ b/srcs/frontend/pong.js
@@ -226,8 +226,6 @@ class Game {
             }
             else {
                 countdownEl.textContent = n.toString();
-                SFX.countdown.currentTime = 0;
-                SFX.countdown.play();
             }
         }, 800);
     }

--- a/srcs/frontend/pong.ts
+++ b/srcs/frontend/pong.ts
@@ -277,8 +277,7 @@ class Game {
         callback();
       } else {
         countdownEl.textContent = n.toString();
-        SFX.countdown.currentTime = 0;
-        SFX.countdown.play();
+        /* play the countdown sound only once at the beginning */
       }
     }, 800);
   }


### PR DESCRIPTION
## Summary
- ensure countdown sound plays only once during the countdown

## Testing
- `npx tsc -p srcs/frontend/tsconfig.json`
- `npx tsc -p srcs/backend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688cdc0974148332a82288c58afad1db