### PR TITLE
Add alias field

### DIFF
--- a/srcs/backend/init/db_init.js
+++ b/srcs/backend/init/db_init.js
@@ -10,26 +10,41 @@ const db = new sqlite3.Database("../db/db.sqlite", (err) => {
 //friends is a json array, for example  '["2", "3", "5", "7"]'
 
 db.run(
-	`CREATE TABLE IF NOT EXISTS users (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	username TEXT NOT NULL UNIQUE,
-	full_name TEXT DEFAULT NULL,
-	email TEXT NOT NULL UNIQUE,
-	password_hash TEXT,
+        `CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL UNIQUE,
+        alias TEXT DEFAULT NULL,
+        full_name TEXT DEFAULT NULL,
+        email TEXT NOT NULL UNIQUE,
+        password_hash TEXT,
 	created_at TEXT DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
 	google_sign_in BOOLEAN DEFAULT FALSE,
 	two_factor_auth	BOOLEAN DEFAULT FALSE,
 	blocked_users TEXT DEFAULT NULL,
 	friends TEXT DEFAULT NULL,
-	avatar TEXT DEFAULT NULL
-	)`,
-	(err) => {
-		if (err) {
-			console.error(err.message);
-		}
-	}
+        avatar TEXT DEFAULT NULL
+        )`,
+        (err) => {
+                if (err) {
+                        console.error(err.message);
+                }
+        }
 );
+
+// Add alias column for existing databases
+db.all("PRAGMA table_info(users)", (err, rows) => {
+        if (err) {
+                console.error(err.message);
+                return;
+        }
+        const hasAlias = rows.some((row) => row.name === "alias");
+        if (!hasAlias) {
+                db.run("ALTER TABLE users ADD COLUMN alias TEXT", (err2) => {
+                        if (err2) console.error(err2.message);
+                });
+        }
+});
 
 db.run(`
 	CREATE TABLE IF NOT EXISTS game_history (

--- a/srcs/backend/user_routes.js
+++ b/srcs/backend/user_routes.js
@@ -12,10 +12,10 @@ async function routes(fastify, options) {
 		},
 		async (request, reply) => {
 			try {
-				const result = await fastify.sqlite.get(
-					"SELECT users.id, users.username, users.email, users.created_at, users.updated_at, users.blocked_users, users.friends, users.avatar, users.full_name, users.two_factor_auth FROM users WHERE id = ?",
-					[request.params.id]
-				);
+                                const result = await fastify.sqlite.get(
+                                        "SELECT users.id, users.username, users.alias, users.email, users.created_at, users.updated_at, users.blocked_users, users.friends, users.avatar, users.full_name, users.two_factor_auth FROM users WHERE id = ?",
+                                        [request.params.id]
+                                );
 				if (!result) {
 					reply.statusCode = 404;
 					return { error: "User not found" };
@@ -52,7 +52,7 @@ async function routes(fastify, options) {
 		async (request, reply) => {
 			try {
                                 const result = await fastify.sqlite.get(
-                                        "SELECT users.id, users.username, users.email, users.created_at, users.updated_at, users.blocked_users, users.friends, users.avatar, users.two_factor_auth FROM users WHERE id = ?",
+                                        "SELECT users.id, users.username, users.alias, users.email, users.created_at, users.updated_at, users.blocked_users, users.friends, users.avatar, users.two_factor_auth FROM users WHERE id = ?",
                                         [request.user.id]
                                 );
 				if (!result) {


### PR DESCRIPTION
## Summary
- extend `users` table definition with an `alias` field
- auto-migrate old DBs by adding the column when missing
- expose `alias` via `/user/:id` and `/currentuser`

## Testing
- `npm test` (backend – expected failure: no test specified)
- `npm test` (frontend – fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_688ce1481e1483328de03f939c6e19be