### PR TITLE
Update navbar name when editing profile

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -57,6 +57,11 @@ export async function openProfile(userId) {
             navAvatar.src = data.avatar
                 ? `${getAvatarUrl(data.avatar)}?_=${Date.now()}`
                 : "/assets/default-avatar.png";
+        const nameEl = document.getElementById("navUsername");
+        if (nameEl) {
+            const aliasVal = (data.alias ?? "").trim() || data.username;
+            nameEl.textContent = aliasVal;
+        }
         const tf = wireTwoFactor(overlay, data);
         wireEdit(overlay, data, tf);
     }

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -117,6 +117,12 @@ export interface GameHistoryRow {
           ? `${getAvatarUrl(data.avatar)}?_=${Date.now()}`
           : "/assets/default-avatar.png";
 
+      const nameEl = document.getElementById("navUsername") as HTMLElement | null;
+      if (nameEl) {
+        const aliasVal = (data.alias ?? "").trim() || data.username;
+        nameEl.textContent = aliasVal;
+      }
+
       const tf = wireTwoFactor(overlay, data);
       wireEdit(overlay, data, tf);
     }


### PR DESCRIPTION
## Summary
- update navbar username when refreshing profile
- compile frontend scripts

## Testing
- `npx tsc -p srcs/frontend`


------
https://chatgpt.com/codex/tasks/task_e_688ce5bd23b08332bcaff11b9145813b