### PR TITLE
Fix profile history score orientation

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -291,7 +291,9 @@ function wireExtraButtons(ov, data) {
             row.appendChild(tdResult);
             const tdScore = document.createElement("td");
             tdScore.className = "px-2";
-            tdScore.textContent = `${g.scoreWinner} – ${g.scoreLoser}`;
+            const yourScore = youWon ? g.scoreWinner : g.scoreLoser;
+            const oppScore = youWon ? g.scoreLoser : g.scoreWinner;
+            tdScore.textContent = `${yourScore} – ${oppScore}`;
             row.appendChild(tdScore);
             if (includeTournament) {
                 const tdTournament = document.createElement("td");

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -421,7 +421,9 @@ export interface GameHistoryRow {
 
         const tdScore = document.createElement("td");
         tdScore.className = "px-2";
-        tdScore.textContent = `${g.scoreWinner} – ${g.scoreLoser}`;
+        const yourScore = youWon ? g.scoreWinner : g.scoreLoser;
+        const oppScore  = youWon ? g.scoreLoser : g.scoreWinner;
+        tdScore.textContent = `${yourScore} – ${oppScore}`;
         row.appendChild(tdScore);
 
         if (includeTournament) {


### PR DESCRIPTION
## Summary
- compute score display relative to the viewer when rendering match history

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_688cebf68ac08332ac58d1020bc8fb39