### PR TITLE
Improve match history timestamps

### DIFF
--- a/srcs/frontend/profile.js
+++ b/srcs/frontend/profile.js
@@ -273,8 +273,9 @@ function wireExtraButtons(ov, data) {
             if (includeTournament)
                 tournament = g.tournament_name ?? String(g.tournamentId ?? "");
             const tdDate = document.createElement("td");
-            tdDate.className = "px-2";
-            tdDate.textContent = g.timestamp.slice(0, 10);
+            tdDate.className = "px-2 whitespace-nowrap";
+            const date = new Date(g.timestamp);
+            tdDate.textContent = date.toLocaleString();
             row.appendChild(tdDate);
             const tdOpponent = document.createElement("td");
             tdOpponent.className = "px-2";

--- a/srcs/frontend/profile.ts
+++ b/srcs/frontend/profile.ts
@@ -400,8 +400,9 @@ export interface GameHistoryRow {
           tournament = g.tournament_name ?? String(g.tournamentId ?? "");
 
         const tdDate = document.createElement("td");
-        tdDate.className = "px-2";
-        tdDate.textContent = g.timestamp.slice(0, 10);
+        tdDate.className = "px-2 whitespace-nowrap";
+        const date = new Date(g.timestamp);
+        tdDate.textContent = date.toLocaleString();
         row.appendChild(tdDate);
 
         const tdOpponent = document.createElement("td");


### PR DESCRIPTION
## Summary
- show full timestamp in profile match history
- keep table responsive with nowrap class

## Testing
- `npx tsc` in `srcs/frontend`
- `npm run build` in `srcs/backend`


------
https://chatgpt.com/codex/tasks/task_e_688ced86bcec83328c091acc0b5ccced